### PR TITLE
due to recent changes to move all extras into my pellcorp/klipper for…

### DIFF
--- a/k1/apply-overrides.sh
+++ b/k1/apply-overrides.sh
@@ -38,6 +38,12 @@ function apply_overrides() {
                 echo "Applying overrides for /usr/data/printer_data/config/$file ..."
                 cp /usr/data/printer_data/config/$file /usr/data/printer_data/config/${file}.override.bkp
                 $CONFIG_HELPER --file $file --overrides $overrides_dir/$file || exit $?
+
+                # if users had their own version of guppyscreen.cfg their config will break because I removed the guppy_module_loader
+                # so be a nice to people and clean that shit up
+                if [ "$file" = "guppyscreen.cfg" ]; then
+                    /usr/data/pellcorp/k1/config-helper.py --file guppyscreen.cfg --remove-section guppy_module_loader
+                fi
               else # if switching probes we might run into this
                 echo "Ignoring overrides for missing /usr/data/printer_data/config/$file"
               fi


### PR DESCRIPTION
…k, I removed the guppy_module_loader as its only used for tmcstatus.py, which was another extra I stopped supporting, so lets clean up the guppy_module_loader include for any users who changed guppyscreen.cfg