### PR TITLE
increase margin of KAMP purge line

### DIFF
--- a/k1/installer.sh
+++ b/k1/installer.sh
@@ -630,6 +630,8 @@ function install_kamp() {
         # lower and longer purge line
         $CONFIG_HELPER --file KAMP_Settings.cfg --replace-section-entry "gcode_macro _KAMP_Settings" variable_purge_height 0.5
         $CONFIG_HELPER --file KAMP_Settings.cfg --replace-section-entry "gcode_macro _KAMP_Settings" variable_purge_amount 48
+        # increase margin of purge line to not conflict with brim/skirt
+        $CONFIG_HELPER --file KAMP_Settings.cfg --replace-section-entry "gcode_macro _KAMP_Settings" variable_purge_margin 20
         # same setting as cancel_retract in start_end.cfg
         $CONFIG_HELPER --file KAMP_Settings.cfg --replace-section-entry "gcode_macro _KAMP_Settings" variable_tip_distance 7.0
 


### PR DESCRIPTION
KAMP uses a default margin of 10 for the purge line. This is too close, when you're printing with brim + skirt.

![image](https://github.com/user-attachments/assets/32fc241c-abb2-43a8-aad1-9e34ccd56305)

I'd propose a setting of 20, so that the purge line will be far away enough for most use cases.