### PR TITLE
dont enable auto dock for klicky out of the box, just for safety reas…

### DIFF
--- a/k1/klicky_macro.cfg
+++ b/k1/klicky_macro.cfg
@@ -1,7 +1,7 @@
 [gcode_macro _KLICKY_VARIABLES]
 variable_probe_attached: False
 # if you want to disable automatic attachment and docking you can set this to False
-variable_auto_docking: True
+variable_auto_docking: False
 # This is mm/minute, not mm/s
 variable_probe_speed: 10000
 # the coordinates of the toolhead where the toolhead portion of the klicky is over the top


### PR DESCRIPTION
…ons, users need to enable that manually after initial setup, config overrides should retain the setting change