### PR TITLE
print end bed position when cooldown - a better default value

### DIFF
--- a/k1/start_end.cfg
+++ b/k1/start_end.cfg
@@ -29,7 +29,7 @@ gcode:
 variable_park_at_cancel: True
 variable_use_custom_pos: True
 # the value in mm to lift the nozzle when move to park position
-variable_custom_park_dz: 25.0
+variable_custom_park_dz: 45.0
 # park position during CANCEL_PRINT and END_PRINT
 variable_park_at_cancel_x: 0.0
 # park position during CANCEL_PRINT and END_PRINT


### PR DESCRIPTION
While some users correctly claim "z-position after print-end is a user setting" I believe the default setting does not create enough distance between bed and nozzle when in cooldown parking position, thus making the plate removal process considerably UnsimpleAF. This PR aims to lower the bed after printing to allow easy plate removal in cooldown park position.