### PR TITLE
when using M84 for cancel print and idle timeout need to clear bed me…

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -93,6 +93,7 @@ gcode:
         RESPOND TYPE=command MSG='Timeout Reached - Turning off heaters and motors'
 
         TURN_OFF_HEATERS
+        BED_MESH_CLEAR
         M84
     {% endif %}
 
@@ -120,6 +121,7 @@ gcode:
 
     TURN_OFF_HEATERS
     TURN_OFF_FANS
+    BED_MESH_CLEAR
     M84
 
 
@@ -370,7 +372,7 @@ gcode:
 
         UPDATE_DELAYED_GCODE ID=wait_for_end_print_cooldown DURATION=1
     {% else %}
-        M84  # motors off
+        M84
         TURN_OFF_FANS
 
         {% if printer["gcode_macro _SAF_END_PRINT_END"] != null %}
@@ -397,7 +399,7 @@ gcode:
   # we already lowered the bed earlier so want to skip it now
   _TOOLHEAD_PARK_END_PRINT SKIP_Z_PARK=1
 
-  M84  # motors off
+  M84
   TURN_OFF_FANS
 
   {% if printer["gcode_macro _SAF_END_PRINT_END"] != null %}


### PR DESCRIPTION
…sh otherwise beacon can

't home again