### PR TITLE
I'm back from the M600 rabbit hole. Fought dragons, chased unicorns, ...

### DIFF
--- a/config/useful_macros.cfg
+++ b/config/useful_macros.cfg
@@ -83,39 +83,46 @@ gcode:
 gcode:
   M109 S{printer['gcode_macro RESUME'].last_extruder_temp.temp|int}
   RESPOND TYPE=command MSG="Unloading filament..."
-  M83
-  G1 E10 F300
-  G1 E-15 F3000
-  G1 E-22.4700 F2400
-  G1 E-6.4200 F1200
-  G1 E-3.2100 F720
-  G1 E5.0000 F356
-  G1 E-5.0000 F384
-  G1 E5.0000 F412
-  G1 E-5.0000 F440
-  G1 E5.0000 F467
-  G1 E-5.0000 F495
-  G1 E5.0000 F523
-  G1 E-5.0000 F3000
-  G1 E-15 F3000
-  M400
+    # Turn on cooling fan to help with temperature drop
+    M106 S255
+    
+    M83
+
+      #### K1* Unicorn Nozzle/Heatbreak/Extruder Geometry:
+      ## pipe - heatbreak - pipe - nozzle
+      ## 23.6 - 10.5      - 3    - 28.3 - total 65.4mm
+      ### Positions:
+      ## E-28.3 = unloaded from nozzle/heater
+      ## E-36.55 = unloaded from nozzle/hb until middle of heatbreak
+      ## E-42.3 = unloaded from nozzle and hb = between heatbreak and extruder drive gears, hand pullable with lever opened
+      ## E-77.5 = unloaded from nozzle, hb and extruder = beyond extruder drive gears, hand pullable with lever closed
+
+      #### CHCB-OTC on K1* Nozzle/Heatbreak/Extruder Geometry:
+      ## pipe - heatbreak - pipe - nozzle
+      ## (23.5 - 10.5      - 3    - 28.5 - total 65.5mm
+      ### Positions:
+      ## E-28.5 = unloaded from nozzle/heater
+      ## E-36.75 = unloaded from nozzle/hb until middle of heatbreak
+      ## E-42.5 = unloaded from nozzle and hb = between heatbreak and extruder drive gears, hand pullable with lever opened
+      ## E-77.5 = unloaded from nozzle, hb and extruder = beyond extruder drive gears, hand pullable with lever closed
+
+      RESPOND MSG="Begin unload filament and tip shape"
+      M104 S{EXTRUDER_TEMP - 30}     # Start cooling (don't wait)
+      G4 P5000                       # Wait for initial cooldown
+      G1 E30 F180                    # initially purge larger due to nozzle length
+      G1 E-12 F600                   # Medium retract -12
+      G4 P1000                       # Wait  
+      G1 E4 F120                     # Small extrude -8
+      G1 E-18 F1400                  # Fast retract -26
+      G4 P500                        # Wait  
+      G1 E2 F90                      # Tiny extrude -24
+      G1 E-24 F2200                  # Very fast retract -48
+      G1 E-50 F2800                  # Final snap retract -98
+      
+    M400
   # turn off extruder to help it avoid overheating
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
   BEEP
-  BEEP
-
-
-[gcode_macro _UNLOAD_MORE]
-gcode:
-  M109 S{printer['gcode_macro RESUME'].last_extruder_temp.temp|int}
-  RESPOND TYPE=command MSG="Unloading filament..."
-  M83
-  G1 E-10 F180
-  M400
-  # turn off extruder to help it avoid overheating
-  SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
-  BEEP
-
 
 [gcode_macro _LOAD_FILAMENT]
 gcode:
@@ -123,6 +130,7 @@ gcode:
   RESPOND TYPE=command MSG="Loading filament..."
   M83
   G1 E100 F180
+  _CLIENT_RETRACT
   M400
   # turn off extruder to help it avoid overheating
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
@@ -135,6 +143,7 @@ gcode:
   RESPOND TYPE=command MSG="Purging filament..."
   M83
   G1 E10 F180
+  _CLIENT_RETRACT
   M400
   # turn off extruder to help it avoid overheating
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
@@ -156,17 +165,24 @@ gcode:
 [gcode_macro M600]
 description: Filament Change
 gcode:
-  RESPOND TYPE=command MSG="Print paused for filament change!"
+  RESPOND TYPE=command MSG="M600 - Print paused for filament change"
   PAUSE RESTORE=0
+  RESPOND TYPE=command MSG="action:prompt_begin M600 - Filament Change - UNLOAD Filament"
+  RESPOND TYPE=command MSG="action:prompt_text BEEP BEEP - Unloading Filament ..."
+  RESPOND TYPE=command MSG="action:prompt_text ... ... ..."
+  RESPOND TYPE=command MSG="action:prompt_text ... Please wait. for BEEP."
+  RESPOND TYPE=command MSG="action:prompt_show"
+  BEEP
+  BEEP
   _UNLOAD_FILAMENT
   M106 P0 S0
   M106 P2 S0
-  RESPOND TYPE=command MSG="action:prompt_begin Filament change detected!"
-  RESPOND TYPE=command MSG="action:prompt_text A necessary filament change has been detected. Please replace filament, LOAD it and click RESUME button."
-  RESPOND TYPE=command MSG="action:prompt_button UNLOAD FILAMENT|_UNLOAD_FILAMENT|secondary"
-  RESPOND TYPE=command MSG="action:prompt_button UNLOAD MORE FILAMENT|_UNLOAD_MORE|secondary"
-  RESPOND TYPE=command MSG="action:prompt_button LOAD FILAMENT|_LOAD_FILAMENT|secondary"
-  RESPOND TYPE=command MSG="action:prompt_button PURGE MORE FILAMENT|_PURGE_MORE|secondary"
+  RESPOND TYPE=command MSG="action:prompt_begin M600 - Filament Change - LOAD Filament"
+  RESPOND TYPE=command MSG="action:prompt_text BEEP - Filament unloaded. Replace Filament, click LOAD, remove purged material and click RESUME when ready to continue print."
+  RESPOND TYPE=command MSG="action:prompt_text  "
+  RESPOND TYPE=command MSG="action:prompt_button LOAD Filament|_LOAD_FILAMENT|secondary"
+  RESPOND TYPE=command MSG="action:prompt_button PURGE MORE Filament|_PURGE_MORE|secondary"
+  RESPOND TYPE=command MSG="action:prompt_text  "
   RESPOND TYPE=command MSG="action:prompt_footer_button CANCEL PRINT|_FC_CANCEL|error"
   RESPOND TYPE=command MSG="action:prompt_footer_button IGNORE|RESPOND TYPE=command MSG=action:prompt_end|warning"
   RESPOND TYPE=command MSG="action:prompt_footer_button RESUME|_FC_RESUME|primary"


### PR DESCRIPTION
and made it back alive!

1) M600: fixing the extruder clog
The _UNLOAD_FILAMENT tip shaping procedure caused a clog. I replaced it to something that reliably does not clog the extruder. The tip forming creates a reusable tip that passes the filament sensos and loads into the extruder flawlessly. Formed tip is with a string that is finger-removable, and could be improved.

2) M600: fixing "ooze" on RESUME after M600
This actually is not an oozing hotend. It actually is a _CLIENT_EXTRUDE called at fully primed nozzle after _LOAD_FILAMENT or _PURGE_MORE. See, PAUSE is calling _CLIENT_RETRACT (default 1mm) and RESUME is calling _CLIENT_EXTRUDE (default 1mm). Since _LOAD_FILAMENT and _PURGE_MORE do extrude filament, the nozzle is fully primed at RESUME, and extrudes (which was considered oozing wrongly.). Fix: Calling _CLIENT_RETRACT at the end of _LOAD_FILANEMT and _PURGE_MORE macros counters the _CLIENT_EXTRUDE from fully primed nozzle.

3) M600: Remove useless Display Entry
_UNLOAD_FILAMENT is already called by M600 after PAUSE. No use case for calling it again from display, hence remove the entry entirely. Also no use case for _UNLOAD_MORE, thus removing entry and macro.

4) M600: Rewrite of Instructions on Display to make more sense.