### PR TITLE
M600: counter temperature change earlier

### DIFF
--- a/config/useful_macros.cfg
+++ b/config/useful_macros.cfg
@@ -123,6 +123,9 @@ gcode:
   # turn off extruder to help it avoid overheating
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
   BEEP
+  # we lowered by -30° before. restore already here to avoid heating at _LOAD_FILAMENT later
+  M109 S{printer['gcode_macro RESUME'].last_extruder_temp.temp|int}
+
 
 [gcode_macro _LOAD_FILAMENT]
 gcode:
@@ -170,7 +173,7 @@ gcode:
   RESPOND TYPE=command MSG="action:prompt_begin M600 - Filament Change - UNLOAD Filament"
   RESPOND TYPE=command MSG="action:prompt_text BEEP BEEP - Unloading Filament ..."
   RESPOND TYPE=command MSG="action:prompt_text ... ... ..."
-  RESPOND TYPE=command MSG="action:prompt_text ... Please wait. for BEEP."
+  RESPOND TYPE=command MSG="action:prompt_text ... Please wait for BEEP."
   RESPOND TYPE=command MSG="action:prompt_show"
   BEEP
   BEEP


### PR DESCRIPTION
welp. Another oversight in the logical process. We reduced -30° earlier for snapping the filament on the last move at unload. Next point to restore last.temp would be at _LOAD_FILAMENT. +30° may take around 10-15 seconds.Tthis is a timeframe a user might deem "something is not working right", because there is nothing happening. Let's reheat to last.temp already at the end of _UNLOAD_FILAMENT.