### PR TITLE
saf rpi k1 printers: add part fan enable pin config

### DIFF
--- a/rpi/printers/creality-k1-2023.cfg
+++ b/rpi/printers/creality-k1-2023.cfg
@@ -198,7 +198,8 @@ square_corner_velocity: 5.0
 max_z_accel: 300
 
 [fan_generic part]
-pin: !nozzle_mcu: PB8
+pin: !nozzle_mcu:PB8
+enable_pin: nozzle_mcu:PB6
 cycle_time: 0.0100
 hardware_pwm: false
 

--- a/rpi/printers/creality-k1-2024.cfg
+++ b/rpi/printers/creality-k1-2024.cfg
@@ -206,7 +206,8 @@ square_corner_velocity: 5.0
 max_z_accel: 300
 
 [fan_generic part]
-pin: !nozzle_mcu: PB8
+pin: !nozzle_mcu:PB8
+enable_pin: nozzle_mcu:PB6
 cycle_time: 0.0100
 hardware_pwm: false
 

--- a/rpi/printers/creality-k1c.cfg
+++ b/rpi/printers/creality-k1c.cfg
@@ -197,8 +197,10 @@ max_accel: 20000
 max_z_velocity: 10
 square_corner_velocity: 5.0
 max_z_accel: 300
+
 [fan_generic part]
-pin: !nozzle_mcu: PB8
+pin: !nozzle_mcu:PB8
+enable_pin: nozzle_mcu:PB6
 cycle_time: 0.0100
 hardware_pwm: false
 

--- a/rpi/printers/creality-k1m-2023.cfg
+++ b/rpi/printers/creality-k1m-2023.cfg
@@ -204,7 +204,8 @@ square_corner_velocity: 5.0
 max_z_accel: 300
 
 [fan_generic part]
-pin: !nozzle_mcu: PB8
+pin: !nozzle_mcu:PB8
+enable_pin: nozzle_mcu:PB6
 cycle_time: 0.0100
 hardware_pwm: false
 

--- a/rpi/printers/creality-k1m-2024.cfg
+++ b/rpi/printers/creality-k1m-2024.cfg
@@ -212,7 +212,8 @@ square_corner_velocity: 5.0
 max_z_accel: 300
 
 [fan_generic part]
-pin: !nozzle_mcu: PB8
+pin: !nozzle_mcu:PB8
+enable_pin: nozzle_mcu:PB6
 cycle_time: 0.0100
 hardware_pwm: false
 

--- a/rpi/printers/creality-k1se.cfg
+++ b/rpi/printers/creality-k1se.cfg
@@ -175,8 +175,10 @@ max_accel: 20000
 max_z_velocity: 10
 square_corner_velocity: 5.0
 max_z_accel: 300
+
 [fan_generic part]
 pin: !nozzle_mcu: PB8
+enable_pin: nozzle_mcu:PB6
 cycle_time: 0.0100
 hardware_pwm: false
 


### PR DESCRIPTION
I'm not sure if this should be solved by an install script change or not, since the printer.cfg postprocessing is different between normal saf and saf rpi + k1 printer, I assume.If this should be an installer change then this can serve as an issue report instead...otherwise here is a basic static config change to implement it across the k series printer definitions.

I have only tested this change with the k1c specifically, but as far as I can tell it is the same hardware config across the line.