### PR TITLE
Added EXTRUDER_TEMP to _SAF_NOZZLE_WIPE macro

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -295,7 +295,7 @@ gcode:
 
       {% if beacon or eddyng or cartographer_touch %}
         {% if printer["gcode_macro _SAF_NOZZLE_WIPE"] != null %}
-              _SAF_NOZZLE_WIPE
+              _SAF_NOZZLE_WIPE EXTRUDER_TEMP={EXTRUDER_TEMP}
           {% endif %}
       {% endif %}
 
@@ -325,7 +325,7 @@ gcode:
       # the carto team strongly recommends tap after bed mesh for scanner.py
       {% if cartotouch %}
         {% if printer["gcode_macro _SAF_NOZZLE_WIPE"] != null %}
-          _SAF_NOZZLE_WIPE
+          _SAF_NOZZLE_WIPE EXTRUDER_TEMP={EXTRUDER_TEMP}
         {% endif %}
 
         # touch samples and retries are configured in cartotouch.cfg


### PR DESCRIPTION
Change to _SAF_NOZZLE_WIPE macro in order to pass EXTRUDER_TEMP for different materials.