### PR TITLE
Update start_end.cfg

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -348,6 +348,9 @@ gcode:
         {% elif cartographer_touch %}
           # touch samples and retries are configured in cartographer.cfg
           CARTOGRAPHER_TOUCH_HOME
+        {% elif printer['output_pin _saf_z_endstop'] != null %}
+          # home printer after bed mesh
+          G28
         {% else %}
           # touch samples and retries are configured in cartotouch.cfg
           CARTOGRAPHER_TOUCH


### PR DESCRIPTION
makes it so if user has added microprobe for z end stop then start config will do a 2nd home after heat soaking the bed so that z offset is correct and takes into account bed warp