### PR TITLE
'Fix typo related to klicky to avoid moving the toolhead to middle of bed after homing in sensorless.cfg

### DIFF
--- a/config/sensorless.cfg
+++ b/config/sensorless.cfg
@@ -77,7 +77,7 @@ gcode:
     {% endfor %}
 
     # do not want post home centering for klicky as we need to attach probe first
-    {% if (not kicky or not home_z) and (home_all or (home_x and home_y)) %}
+    {% if (not klicky or not home_z) and (home_all or (home_x and home_y)) %}
       _POST_HOME_XY
     {% endif %}
 


### PR DESCRIPTION
Fix typo from kicky to klicky