### PR TITLE
Update sensorless.cfg so microprobe always homes at specific point when used as endstop

### DIFF
--- a/config/sensorless.cfg
+++ b/config/sensorless.cfg
@@ -174,6 +174,9 @@ gcode:
   {% if klicky %}
     ATTACH_PROBE MANUAL=0
   {% elif printer['output_pin _saf_z_endstop'] != null %}
+    {% set home_x = printer["gcode_macro _SENSORLESS_PARAMS"].home_x|int %}
+    {% set home_y = printer["gcode_macro _SENSORLESS_PARAMS"].home_y|int %}
+    G90
     SET_PIN PIN=_saf_z_endstop VALUE=1
   {% endif %}
 

--- a/config/sensorless.cfg
+++ b/config/sensorless.cfg
@@ -177,6 +177,7 @@ gcode:
     {% set home_x = printer["gcode_macro _SENSORLESS_PARAMS"].home_x|int %}
     {% set home_y = printer["gcode_macro _SENSORLESS_PARAMS"].home_y|int %}
     G90
+    G0 X{home_x} Y{home_y} F15000
     SET_PIN PIN=_saf_z_endstop VALUE=1
   {% endif %}
 


### PR DESCRIPTION
just adds a couple of lines so when using endstop like microprobe it will always probe at same location, without this line the toolhead will attempt to probe z where it feels like without making sure its in a safe location to do so, similar to how bed mesh does it zero point reference for touch home on carto etc