### PR TITLE
Update cartographer.cfg to remove sample count and allow the cartographer software to handle this instead

### DIFF
--- a/config/cartographer.cfg
+++ b/config/cartographer.cfg
@@ -22,7 +22,6 @@ mesh_runs: 2
 
 # if you want to only do scan, disable this section
 [cartographer touch]
-samples: 5
 max_samples: 20
 # this allows a slight fluctuation above the 150c target to avoid errors
 # hopefully this can be removed if the carto plugin is updated to allow up to 5c of variance


### PR DESCRIPTION
this just removes sample the default for 1.0.2 the current stable build to this date uses 5 as default but future release 1.1.0 will be changing to 3 this just allows carto software to handle this instead of saf needing to