### PR TITLE
grumpyscreen was using hard coded EVDEV name that was often allocated…

### DIFF
--- a/k1/installer.sh
+++ b/k1/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # this allows us to make changes to Simple AF and grumpyscreen in parallel
-GRUMPYSCREEN_TIMESTAMP=1764903500
+GRUMPYSCREEN_TIMESTAMP=1764996800
 GRUMPYSCREEN_BRANCH=main
 
 if [ -f /usr/bin/get_sn_mac.sh ]; then

--- a/rpi/install-grumpyscreen.sh
+++ b/rpi/install-grumpyscreen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # this allows us to make changes to Simple AF and grumpyscreen in parallel
-GRUMPYSCREEN_TIMESTAMP=1764903500
+GRUMPYSCREEN_TIMESTAMP=1764996800
 
 BASEDIR=$HOME
 source $BASEDIR/pellcorp/rpi/functions.sh

--- a/rpi/services/grumpyscreen.service
+++ b/rpi/services/grumpyscreen.service
@@ -10,6 +10,8 @@ Restart=always
 RestartSec=1
 User=pi
 WorkingDirectory=$HOME/guppyscreen
+# this is the DSI default path on RPI far as I can see
+Environment="LVGL_EVDEV_DEV=/dev/input/by-path/platform-soc:firmware:touchscreen-event"
 Environment="WPA_SUPPLICANT_SOCKET=/var/run/wpa_supplicant"
 ExecStartPre="$HOME/guppyscreen/cursor.sh"
 ExecStart="$HOME/guppyscreen/guppyscreen"


### PR DESCRIPTION
… to something else