### PR TITLE
Set nozzle preheat temp to 148 instead of 150, along with changing M190 to M140 in stop heaters

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -12,7 +12,7 @@ variable_start_max_accel: 10000
 # max square corner velocity for bed mesh calibrate
 variable_start_square_corner_velocity: 5.0
 # what to heat nozzle to just before oozing
-variable_start_preheat_nozzle_temp: 150
+variable_start_preheat_nozzle_temp: 148
 # whether to do cooldown routine in END_PRINT
 variable_end_print_cool_down: True
 variable_end_print_cool_down_nozzle_temp: 70.0
@@ -301,7 +301,7 @@ gcode:
         {% if stop_heaters_for_touch %}
           RESPOND TYPE=command MSG='Stopping heaters before touch ...'
           M104 S0
-          M190 S0
+          M140 S0
         {% endif %}
 
         # touch samples and retries are configured in eddyng.cfg

--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -339,7 +339,7 @@ gcode:
         {% if stop_heaters_for_touch %}
           RESPOND TYPE=command MSG='Stopping heaters before touch ...'
           M104 S0
-          M190 S0
+          M140 S0
         {% endif %}
 
         {% if beacon %}


### PR DESCRIPTION
So what ive done is change it so nozzle only goes to 148 instead of 150 for touch on stuff like cartographer, this is due to new software causing issues at 150 due to it really not liking it when you go over, i have also replaced the M190 with M140 in the stop heaters section, the reason for this change is due to M190 usually being for a wait until it reaches this temp, which works fine but if a user lets say manually sets it to 5 or something then the printer will sit there waiting, where as M140 it just continue

Ive tested this on all my machines most are not saf but use the saf configs and one is the k1 mcu and they have worked as expected for me