### PR TITLE
instead of letting klipperscreen reboot the device, where network man…

### DIFF
--- a/rpi/install-klipperscreen.sh
+++ b/rpi/install-klipperscreen.sh
@@ -30,6 +30,12 @@ if [ $? -ne 0 ]; then
 
     # skip setting up network manager, should do it manually if required
     NETWORK=n SERVICE=y BACKEND=X ./KlipperScreen/scripts/KlipperScreen-install.sh
+
+    # manually enable non root users managing network connections for debian where network manager is used
+    if [ -d /etc/NetworkManager/conf.d ]; then
+      sudo cp $BASEDIR/pellcorp/rpi/klipperscreen-any-user.conf /etc/NetworkManager/conf.d/any-user.conf
+      sudo systemctl reload NetworkManager
+    fi
     cd - > /dev/null
   fi
 

--- a/rpi/klipperscreen-any-user.conf
+++ b/rpi/klipperscreen-any-user.conf
@@ -1,0 +1,2 @@
+[main]
+auth-polkit=false


### PR DESCRIPTION
…ager exists already create the any-user.conf file and reload