### PR TITLE
fix nozzle not cooling before touch when wipe is active

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -302,11 +302,12 @@ gcode:
       G4 P500  # wait required to prevent MCU overload / inconsistent meshing
 
       {% if eddyng %}
-        M109 S{preheat_nozzle_temp} # wait for nozzle temp
-
         {% if printer["gcode_macro _SAF_NOZZLE_WIPE"] != null %}
           _SAF_NOZZLE_WIPE {rawparams}
         {% endif %}
+
+        # wipe may or may not fully heat the nozzle, so wait for preheat temp here
+        M109 S{preheat_nozzle_temp} # wait for nozzle temp
 
         {% if stop_heaters_for_touch %}
           RESPOND TYPE=command MSG='Stopping heaters before touch ...'
@@ -340,11 +341,12 @@ gcode:
 
       # the carto team strongly recommends tap after bed mesh for scanner.py
       {% if cartotouch or beacon or cartographer_touch %}
-        M109 S{preheat_nozzle_temp} # wait for nozzle temp
-
         {% if printer["gcode_macro _SAF_NOZZLE_WIPE"] != null %}
           _SAF_NOZZLE_WIPE {rawparams}
         {% endif %}
+
+        # wipe may or may not fully heat the nozzle, so wait for preheat temp here
+        M109 S{preheat_nozzle_temp} # wait for nozzle temp
 
         {% if stop_heaters_for_touch %}
           RESPOND TYPE=command MSG='Stopping heaters before touch ...'


### PR DESCRIPTION
The nozzle wipe procedure, depending on its configuration, may or may not heat the nozzle to temperatures above the preheat target. In the default scenario, touch-based probes (beacon, cartographer, cartotouch, eddyng) require the nozzle to be at or below the preheat temperature (default 150C) to avoid damaging the PEI build plate.

Previously, `M109` (blocking wait for preheat) was placed before the wipe call. This meant the nozzle was guaranteed hot before the wipe, but after the wipe — if it had heated further — nothing waited for it to cool back down before the touch.

The fix moves `M109` to after the wipe. This handles both cases:
- If the wipe left the nozzle cold, `M109` heats it to preheat temp
- If the wipe left the nozzle hot, `M109` waits for it to cool down to preheat temp

Applies to both eddyng and beacon/cartographer/cartotouch touch sequences.