### PR TITLE
M8p base printers

### DIFF
--- a/rpi/printers/creality-btt-m8p-tmc2209-k1-2023.cfg
+++ b/rpi/printers/creality-btt-m8p-tmc2209-k1-2023.cfg
@@ -1,0 +1,227 @@
+# Creality K1 BTT M8P with TMC2209 drivers
+# MODEL:k1
+
+[mcu]
+serial: /dev/ttyGS0
+baud: 250000
+restart_method: command
+
+[mcu nozzle_mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+baud: 230400
+restart_method: command
+
+[verify_heater extruder]
+[verify_heater heater_bed]
+check_gain_time: 120
+heating_gain: 1.0
+hysteresis: 10
+
+[gcode_arcs]
+resolution: 1.0
+
+[temperature_sensor mcu_temp]
+sensor_type: temperature_mcu
+min_temp: 0
+max_temp: 100
+
+[temperature_sensor chamber_temp]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+min_temp: 0
+max_temp: 125
+
+[duplicate_pin_override]
+pins: PB0, PB1, PF9, PA2
+
+[temperature_fan chamber_fan]
+pin: PF9
+cycle_time: 0.0100
+hardware_pwm: true
+max_power: 1
+shutdown_speed: 0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+control: watermark
+max_delta: 1
+target_temp: 0
+min_temp: 0
+max_temp: 85
+
+[stepper_x] # M1 slot
+step_pin: PE6
+dir_pin: PE5
+enable_pin: !PC14
+microsteps: 32
+rotation_distance: 72
+endstop_pin: tmc2209_stepper_x:virtual_endstop
+position_endstop: 229
+position_min: -5
+position_max: 229
+homing_speed: 36
+homing_retract_dist:0
+
+[tmc2209 stepper_x]
+uart_pin: PC13
+interpolate: True
+run_current:1.5
+sense_resistor: 0.100
+stealthchop_threshold: 0
+uart_address:3
+diag_pin: ^PF4
+driver_SGTHRS: 65
+
+[stepper_y] # M2 slot
+step_pin: PE2
+dir_pin: PE1
+enable_pin: !PE4
+microsteps: 32
+rotation_distance: 72
+endstop_pin: tmc2209_stepper_y:virtual_endstop
+position_endstop: -0.5
+position_min: -0.5
+position_max: 226
+homing_speed: 36
+homing_retract_dist:0
+
+[tmc2209 stepper_y]
+uart_pin: PE3
+interpolate: True
+run_current:1.5
+sense_resistor: 0.100
+stealthchop_threshold: 0
+uart_address:3
+diag_pin: ^PF3
+driver_SGTHRS: 65
+
+[stepper_z] # M3 slot
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PE0
+microsteps: 16
+rotation_distance:8
+gear_ratio: 64:20
+endstop_pin: tmc2209_stepper_z:virtual_endstop# PA15   #probe:z_virtual_endstop
+position_endstop: 0
+position_max: 255
+position_min: -5
+
+[tmc2209 stepper_z]
+uart_pin: PB9
+uart_address: 3
+run_current: 0.8
+diag_pin: ^PB14
+stealthchop_threshold: 0
+sense_resistor: 0.100
+driver_SGTHRS: 0
+
+[extruder]
+max_extrude_only_distance: 1000.0
+max_extrude_cross_section: 80
+step_pin: nozzle_mcu:PB1
+dir_pin: nozzle_mcu:PB0
+enable_pin: !nozzle_mcu:PB2
+microsteps: 16
+rotation_distance: 6.9
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: nozzle_mcu:PB7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: nozzle_mcu:PA0
+pressure_advance: 0.04
+pressure_advance_smooth_time: 0.040
+control: pid
+pid_Kp: 25.013
+pid_Ki: 2.566
+pid_Kd: 60.966
+min_temp: 0
+max_temp: 320
+
+[tmc2209 extruder]
+uart_pin: nozzle_mcu:PB11
+tx_pin: nozzle_mcu:PB10
+uart_address: 3
+run_current: 0.55
+sense_resistor: 0.150
+stealthchop_threshold: 0
+
+[heater_bed]
+heater_pin: PF5
+sensor_type: EPCOS 100K B57560G104F #Generic 3950 with AC bed
+sensor_pin: PB0
+control: watermark
+min_temp: 0
+max_temp: 115 # 130 with AC bed
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: true
+switch_pin: !PC15
+runout_gcode:
+  {% if printer.extruder.can_extrude|lower == 'true' %}
+    G91
+    G0 E30 F600
+    G90
+  {% endif %}
+
+[filament_switch_sensor filament_sensor_2]
+pause_on_runout: true
+switch_pin: !nozzle_mcu:PA10
+
+[output_pin LED]
+pin:PA4
+pwm: True
+cycle_time: 0.010
+value: 1
+
+[adxl345]
+cs_pin: nozzle_mcu:PA4
+spi_speed: 5000000
+axes_map: x,-z,y
+spi_software_sclk_pin: nozzle_mcu:PA5
+spi_software_mosi_pin: nozzle_mcu:PA7
+spi_software_miso_pin: nozzle_mcu:PA6
+
+[resonance_tester]
+accel_chip: adxl345
+accel_per_hz: 75
+probe_points:
+   110,110,10
+
+[printer]
+kinematics: corexy
+max_velocity: 800
+max_accel: 20000
+max_z_velocity: 20
+square_corner_velocity: 5.0
+max_z_accel: 300
+
+[fan] #Part cooling fan
+pin: !nozzle_mcu: PB8
+cycle_time: 0.0100
+hardware_pwm: false
+enable_pin: nozzle_mcu:PB6
+kick_start_time: 0.2
+shutdown_speed: 0
+max_power: 1.0
+
+[fan_generic auxiliary]
+pin: PF7
+max_power: 1.0
+shutdown_speed: 0.0
+kick_start_time: 0.100
+cycle_time: 0.002
+hardware_pwm: false
+
+[fan_generic chamber]
+pin: PF9
+shutdown_speed: 0.0
+kick_start_time: 0.100
+cycle_time: 0.0100
+hardware_pwm: false
+
+[heater_fan hotend]
+pin: nozzle_mcu:PB5
+tachometer_pin: ^nozzle_mcu:PB4
+heater: extruder
+heater_temp: 40
+

--- a/rpi/printers/creality-btt-m8p-tmc2240-220v-k1-2023.cfg
+++ b/rpi/printers/creality-btt-m8p-tmc2240-220v-k1-2023.cfg
@@ -1,0 +1,231 @@
+# Creality K1 BTT M8P with TMC2204 drivers and AC bed
+# MODEL:k1
+
+[mcu]
+serial: /dev/ttyGS0
+baud: 250000
+restart_method: command
+
+[mcu nozzle_mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+baud: 230400
+restart_method: command
+
+[verify_heater extruder]
+[verify_heater heater_bed]
+check_gain_time: 120
+heating_gain: 1.0
+hysteresis: 10
+
+[gcode_arcs]
+resolution: 1.0
+
+[temperature_sensor mcu_temp]
+sensor_type: temperature_mcu
+min_temp: 0
+max_temp: 100
+
+[temperature_sensor chamber_temp]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+min_temp: 0
+max_temp: 125
+
+[duplicate_pin_override]
+pins: PB0, PB1, PF9, PA2
+
+[temperature_fan chamber_fan]
+pin: PF9
+cycle_time: 0.0100
+hardware_pwm: true
+max_power: 1
+shutdown_speed: 0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+control: watermark
+max_delta: 1
+target_temp: 0
+min_temp: 0
+max_temp: 85
+
+[stepper_x] # M1 slot
+step_pin: PE6
+dir_pin: PE5
+enable_pin: !PC14
+microsteps: 32
+rotation_distance: 72
+endstop_pin: tmc2240_stepper_x:virtual_endstop
+position_endstop: 229
+position_min: -5
+position_max: 229
+homing_speed: 36
+homing_retract_dist:0
+
+[tmc2240 stepper_x]
+cs_pin: PC13
+interpolate: true
+spi_software_mosi_pin: PG6
+spi_software_miso_pin: PG7
+spi_software_sclk_pin: PG8
+run_current:1.5
+sense_resistor: 0.100
+stealthchop_threshold: 0
+diag0_pin: ^!PF4
+driver_sgt: 2
+
+[stepper_y] # M2 slot
+step_pin: PE2
+dir_pin: PE1
+enable_pin: !PE4
+microsteps: 32
+rotation_distance: 72
+endstop_pin: tmc2240_stepper_y:virtual_endstop
+position_endstop: -0.5
+position_min: -0.5
+position_max: 226
+homing_speed: 36
+homing_retract_dist:0
+
+[tmc2240 stepper_y]
+cs_pin: PE3
+interpolate: true
+spi_software_mosi_pin: PG6
+spi_software_miso_pin: PG7
+spi_software_sclk_pin: PG8
+run_current:1.5
+sense_resistor: 0.100
+stealthchop_threshold: 0
+diag0_pin: ^!PF3
+driver_sgt: 2
+
+[stepper_z] # M3 slot
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PE0
+microsteps: 16
+rotation_distance:8
+gear_ratio: 64:20
+endstop_pin: tmc2209_stepper_z:virtual_endstop# PA15   #probe:z_virtual_endstop
+position_endstop: 0
+position_max: 255
+position_min: -5
+
+[tmc2209 stepper_z]
+uart_pin: PB9
+uart_address: 3
+run_current: 0.8
+diag_pin: ^PB14
+stealthchop_threshold: 0
+sense_resistor: 0.100
+driver_SGTHRS: 0
+
+[extruder]
+max_extrude_only_distance: 1000.0
+max_extrude_cross_section: 80
+step_pin: nozzle_mcu:PB1
+dir_pin: nozzle_mcu:PB0
+enable_pin: !nozzle_mcu:PB2
+microsteps: 16
+rotation_distance: 6.9
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: nozzle_mcu:PB7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: nozzle_mcu:PA0
+pressure_advance: 0.04
+pressure_advance_smooth_time: 0.040
+control: pid
+pid_Kp: 25.013
+pid_Ki: 2.566
+pid_Kd: 60.966
+min_temp: 0
+max_temp: 320
+
+[tmc2209 extruder]
+uart_pin: nozzle_mcu:PB11
+tx_pin: nozzle_mcu:PB10
+uart_address: 3
+run_current: 0.55
+sense_resistor: 0.150
+stealthchop_threshold: 0
+
+[heater_bed]
+heater_pin: PF5
+sensor_type: Generic 3950
+sensor_pin: PB0
+control: watermark
+min_temp: 0
+max_temp: 130
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: true
+switch_pin: !PC15
+runout_gcode:
+  {% if printer.extruder.can_extrude|lower == 'true' %}
+    G91
+    G0 E30 F600
+    G90
+  {% endif %}
+
+[filament_switch_sensor filament_sensor_2]
+pause_on_runout: true
+switch_pin: !nozzle_mcu:PA10
+
+[output_pin LED]
+pin:PA4
+pwm: True
+cycle_time: 0.010
+value: 1
+
+[adxl345]
+cs_pin: nozzle_mcu:PA4
+spi_speed: 5000000
+axes_map: x,-z,y
+spi_software_sclk_pin: nozzle_mcu:PA5
+spi_software_mosi_pin: nozzle_mcu:PA7
+spi_software_miso_pin: nozzle_mcu:PA6
+
+[resonance_tester]
+accel_chip: adxl345
+accel_per_hz: 75
+probe_points:
+   110,110,10
+
+[printer]
+kinematics: corexy
+max_velocity: 800
+max_accel: 20000
+max_z_velocity: 20
+square_corner_velocity: 5.0
+max_z_accel: 300
+
+[fan] #Part cooling fan
+pin: !nozzle_mcu: PB8
+cycle_time: 0.0100
+hardware_pwm: false
+enable_pin: nozzle_mcu:PB6
+kick_start_time: 0.2
+shutdown_speed: 0
+max_power: 1.0
+
+[fan_generic auxiliary]
+pin: PF7
+max_power: 1.0
+shutdown_speed: 0.0
+kick_start_time: 0.100
+cycle_time: 0.002
+hardware_pwm: false
+
+[fan_generic chamber]
+pin: PF9
+shutdown_speed: 0.0
+kick_start_time: 0.100
+cycle_time: 0.0100
+hardware_pwm: false
+
+[heater_fan hotend]
+pin: nozzle_mcu:PB5
+tachometer_pin: ^nozzle_mcu:PB4
+heater: extruder
+heater_temp: 40
+

--- a/rpi/printers/creality-btt-m8p-tmc2240-k1-2023.cfg
+++ b/rpi/printers/creality-btt-m8p-tmc2240-k1-2023.cfg
@@ -1,0 +1,231 @@
+# Creality K1 BTT M8P with TMC2204 drivers
+# MODEL:k1
+
+[mcu]
+serial: /dev/ttyGS0
+baud: 250000
+restart_method: command
+
+[mcu nozzle_mcu]
+serial: /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+baud: 230400
+restart_method: command
+
+[verify_heater extruder]
+[verify_heater heater_bed]
+check_gain_time: 120
+heating_gain: 1.0
+hysteresis: 10
+
+[gcode_arcs]
+resolution: 1.0
+
+[temperature_sensor mcu_temp]
+sensor_type: temperature_mcu
+min_temp: 0
+max_temp: 100
+
+[temperature_sensor chamber_temp]
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+min_temp: 0
+max_temp: 125
+
+[duplicate_pin_override]
+pins: PB0, PB1, PF9, PA2
+
+[temperature_fan chamber_fan]
+pin: PF9
+cycle_time: 0.0100
+hardware_pwm: true
+max_power: 1
+shutdown_speed: 0
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: PB1
+control: watermark
+max_delta: 1
+target_temp: 0
+min_temp: 0
+max_temp: 85
+
+[stepper_x] # M1 slot
+step_pin: PE6
+dir_pin: PE5
+enable_pin: !PC14
+microsteps: 32
+rotation_distance: 72
+endstop_pin: tmc2240_stepper_x:virtual_endstop
+position_endstop: 229
+position_min: -5
+position_max: 229
+homing_speed: 36
+homing_retract_dist:0
+
+[tmc2240 stepper_x]
+cs_pin: PC13
+interpolate: true
+spi_software_mosi_pin: PG6
+spi_software_miso_pin: PG7
+spi_software_sclk_pin: PG8
+run_current:1.5
+sense_resistor: 0.100
+stealthchop_threshold: 0
+diag0_pin: ^!PF4
+driver_sgt: 2
+
+[stepper_y] # M2 slot
+step_pin: PE2
+dir_pin: PE1
+enable_pin: !PE4
+microsteps: 32
+rotation_distance: 72
+endstop_pin: tmc2240_stepper_y:virtual_endstop
+position_endstop: -0.5
+position_min: -0.5
+position_max: 226
+homing_speed: 36
+homing_retract_dist:0
+
+[tmc2240 stepper_y]
+cs_pin: PE3
+interpolate: true
+spi_software_mosi_pin: PG6
+spi_software_miso_pin: PG7
+spi_software_sclk_pin: PG8
+run_current:1.5
+sense_resistor: 0.100
+stealthchop_threshold: 0
+diag0_pin: ^!PF3
+driver_sgt: 2
+
+[stepper_z] # M3 slot
+step_pin: PB8
+dir_pin: PB7
+enable_pin: !PE0
+microsteps: 16
+rotation_distance:8
+gear_ratio: 64:20
+endstop_pin: tmc2209_stepper_z:virtual_endstop# PA15   #probe:z_virtual_endstop
+position_endstop: 0
+position_max: 255
+position_min: -5
+
+[tmc2209 stepper_z]
+uart_pin: PB9
+uart_address: 3
+run_current: 0.8
+diag_pin: ^PB14
+stealthchop_threshold: 0
+sense_resistor: 0.100
+driver_SGTHRS: 0
+
+[extruder]
+max_extrude_only_distance: 1000.0
+max_extrude_cross_section: 80
+step_pin: nozzle_mcu:PB1
+dir_pin: nozzle_mcu:PB0
+enable_pin: !nozzle_mcu:PB2
+microsteps: 16
+rotation_distance: 6.9
+nozzle_diameter: 0.400
+filament_diameter: 1.750
+heater_pin: nozzle_mcu:PB7
+sensor_type: EPCOS 100K B57560G104F
+sensor_pin: nozzle_mcu:PA0
+pressure_advance: 0.04
+pressure_advance_smooth_time: 0.040
+control: pid
+pid_Kp: 25.013
+pid_Ki: 2.566
+pid_Kd: 60.966
+min_temp: 0
+max_temp: 320
+
+[tmc2209 extruder]
+uart_pin: nozzle_mcu:PB11
+tx_pin: nozzle_mcu:PB10
+uart_address: 3
+run_current: 0.55
+sense_resistor: 0.150
+stealthchop_threshold: 0
+
+[heater_bed]
+heater_pin: PF5
+sensor_type: EPCOS 100K B57560G104F #Generic 3950 with AC bed
+sensor_pin: PB0
+control: watermark
+min_temp: 0
+max_temp: 115 # 130 with AC bed
+
+[filament_switch_sensor filament_sensor]
+pause_on_runout: true
+switch_pin: !PC15
+runout_gcode:
+  {% if printer.extruder.can_extrude|lower == 'true' %}
+    G91
+    G0 E30 F600
+    G90
+  {% endif %}
+
+[filament_switch_sensor filament_sensor_2]
+pause_on_runout: true
+switch_pin: !nozzle_mcu:PA10
+
+[output_pin LED]
+pin:PA4
+pwm: True
+cycle_time: 0.010
+value: 1
+
+[adxl345]
+cs_pin: nozzle_mcu:PA4
+spi_speed: 5000000
+axes_map: x,-z,y
+spi_software_sclk_pin: nozzle_mcu:PA5
+spi_software_mosi_pin: nozzle_mcu:PA7
+spi_software_miso_pin: nozzle_mcu:PA6
+
+[resonance_tester]
+accel_chip: adxl345
+accel_per_hz: 75
+probe_points:
+   110,110,10
+
+[printer]
+kinematics: corexy
+max_velocity: 800
+max_accel: 20000
+max_z_velocity: 20
+square_corner_velocity: 5.0
+max_z_accel: 300
+
+[fan] #Part cooling fan
+pin: !nozzle_mcu: PB8
+cycle_time: 0.0100
+hardware_pwm: false
+enable_pin: nozzle_mcu:PB6
+kick_start_time: 0.2
+shutdown_speed: 0
+max_power: 1.0
+
+[fan_generic auxiliary]
+pin: PF7
+max_power: 1.0
+shutdown_speed: 0.0
+kick_start_time: 0.100
+cycle_time: 0.002
+hardware_pwm: false
+
+[fan_generic chamber]
+pin: PF9
+shutdown_speed: 0.0
+kick_start_time: 0.100
+cycle_time: 0.0100
+hardware_pwm: false
+
+[heater_fan hotend]
+pin: nozzle_mcu:PB5
+tachometer_pin: ^nozzle_mcu:PB4
+heater: extruder
+heater_temp: 40
+


### PR DESCRIPTION
added 3 files:

- BTT M8P TMC2209 K1 (stock bed heater)
- BTT M8P TMC2240 K1 (stock bed heater)
- BTT M8P TMC2240 220V K1 ( 220V AC bed heater)

Removed duplicate pins for bed fans and other unused pins, cleaned up every possible non-stock config apart from M8P board.

It might miss things or needs some tweaking but i was too tired to say 100% sure this is flawless