### PR TITLE
Restore heaters after failed touch probe

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -32,6 +32,17 @@ variable_after_touch_wait_for_bed: False
 variable_full_bed_mesh_above_percentage_full: 75.0
 gcode:
 
+[gcode_macro _TOUCH_HEATER_STATE]
+variable_bed_target: 0.0
+variable_extruder_target: 0.0
+variable_needs_restore: False
+gcode:
+  {% set BED_TARGET = params.BED_TARGET|default(0)|float %}
+  {% set EXTRUDER_TARGET = params.EXTRUDER_TARGET|default(0)|float %}
+  SET_GCODE_VARIABLE MACRO=_TOUCH_HEATER_STATE VARIABLE=bed_target VALUE={BED_TARGET}
+  SET_GCODE_VARIABLE MACRO=_TOUCH_HEATER_STATE VARIABLE=extruder_target VALUE={EXTRUDER_TARGET}
+  SET_GCODE_VARIABLE MACRO=_TOUCH_HEATER_STATE VARIABLE=needs_restore VALUE=True
+
 [gcode_macro _CLIENT_VARIABLE]
 # Do not change these
 variable_park_at_cancel: True
@@ -142,6 +153,18 @@ gcode:
   {% endif %}
 
   TURN_OFF_HEATERS
+
+  {% if printer["gcode_macro _TOUCH_HEATER_STATE"].needs_restore %}
+    {% set bed_target = printer["gcode_macro _TOUCH_HEATER_STATE"].bed_target %}
+    {% set extruder_target = printer["gcode_macro _TOUCH_HEATER_STATE"].extruder_target %}
+    {% if bed_target > 0 or extruder_target > 0 %}
+      RESPOND TYPE=command MSG='Restoring heaters for retry after failed touch: bed={bed_target} nozzle={extruder_target}'
+      M140 S{bed_target}
+      M104 S{extruder_target}
+    {% endif %}
+    SET_GCODE_VARIABLE MACRO=_TOUCH_HEATER_STATE VARIABLE=needs_restore VALUE=False
+  {% endif %}
+
   TURN_OFF_FANS
 
   {% if 'bed_mesh' in printer.configfile.settings %}
@@ -279,6 +302,7 @@ gcode:
 
       {% set stop_heaters_for_touch = printer["gcode_macro _START_END_PARAMS"].stop_heaters_for_touch %}
       {% if stop_heaters_for_touch %}
+        _TOUCH_HEATER_STATE BED_TARGET={BED_TEMP} EXTRUDER_TARGET={preheat_nozzle_temp}
         RESPOND TYPE=command MSG='Stopping heaters before touch ...'
         M104 S0
         M140 S0
@@ -287,6 +311,7 @@ gcode:
       _PROBE_EDDY_NG_TAP_HOME
 
       {% if stop_heaters_for_touch %}
+        SET_GCODE_VARIABLE MACRO=_TOUCH_HEATER_STATE VARIABLE=needs_restore VALUE=False
         RESPOND TYPE=command MSG='Starting heaters after touch ...'
         M140 S{BED_TEMP}
         M104 S{preheat_nozzle_temp} # we can't heat eddyng to temp as bed mesh still to do
@@ -309,6 +334,7 @@ gcode:
 
       {% set stop_heaters_for_touch = printer["gcode_macro _START_END_PARAMS"].stop_heaters_for_touch %}
       {% if stop_heaters_for_touch %}
+        _TOUCH_HEATER_STATE BED_TARGET={BED_TEMP} EXTRUDER_TARGET={preheat_nozzle_temp}
         RESPOND TYPE=command MSG='Stopping heaters before touch ...'
         M104 S0
         M140 S0
@@ -323,6 +349,7 @@ gcode:
       {% endif %}
 
       {% if stop_heaters_for_touch %}
+        SET_GCODE_VARIABLE MACRO=_TOUCH_HEATER_STATE VARIABLE=needs_restore VALUE=False
         RESPOND TYPE=command MSG='Starting heaters after touch ...'
         {% set after_touch_wait_for_bed = printer["gcode_macro _START_END_PARAMS"].after_touch_wait_for_bed %}
         {% if after_touch_wait_for_bed %}


### PR DESCRIPTION
## Problem

When `stop_heaters_for_touch` is enabled, `START_PRINT` turns off heaters before calling touch (`_CARTOGRAPHER_TOUCH_HOME`, `_BEACON_CONTACT_HOME`, `_PROBE_EDDY_NG_TAP_HOME`). If touch fails, Klipper raises an exception that aborts the macro immediately — the heater restore block after the touch call never runs. The bed and nozzle stay at 0°C.

The user then has to manually reheat the bed (often 5+ minutes) before they can retry the print.

## Why it can't be caught in-macro

Klipper's Jinja2 macro system has no try/except. When a sub-command raises an exception, execution of the current macro stops and the error propagates up. There is no way to detect failure inline.

## Solution

Save the target temps into a `_TOUCH_HEATER_STATE` macro variable **before** heaters are turned off, along with a `needs_restore` flag. On success, the flag is cleared. In `_ON_CANCEL` (which runs when the user cancels after the failure), check the flag and restart the heaters — so by the time the user investigates and retries, the bed is already climbing back to temp.

Covers eddyng, cartographer touch, cartotouch, and beacon contact paths.

Verified by manually simulating the failure state and confirming `_ON_CANCEL` restores heaters correctly.

Closes #1319