### PR TITLE
clarify what no connect means for usb probes

### DIFF
--- a/config/beacon.cfg
+++ b/config/beacon.cfg
@@ -1,6 +1,7 @@
 [beacon]
 is_non_critical: true
-no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+# if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+no_reconnect: true
 skip_firmware_version_check: true
 serial: /dev/serial/by-id/XXX
 x_offset: -18.665

--- a/config/beacon.cfg
+++ b/config/beacon.cfg
@@ -1,6 +1,6 @@
 [beacon]
 is_non_critical: true
-no_reconnect: true # reconnecting beacon causes klipper to crash
+no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
 skip_firmware_version_check: true
 serial: /dev/serial/by-id/XXX
 x_offset: -18.665

--- a/config/btteddy.cfg
+++ b/config/btteddy.cfg
@@ -1,6 +1,6 @@
 [mcu eddy]
 is_non_critical: true
-no_reconnect: true # reconnecting eddy causes klipper to crash
+no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
 serial: /dev/serial/by-id/XXX  # change this based on your device path
 restart_method: command
 

--- a/config/btteddy.cfg
+++ b/config/btteddy.cfg
@@ -1,6 +1,7 @@
 [mcu eddy]
 is_non_critical: true
-no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+# if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+no_reconnect: true
 serial: /dev/serial/by-id/XXX  # change this based on your device path
 restart_method: command
 

--- a/config/cartographer.cfg
+++ b/config/cartographer.cfg
@@ -8,7 +8,7 @@ gcode:
 
 [mcu cartographer]
 is_non_critical: true
-no_reconnect: true # reconnecting cartographer causes klipper to crash
+no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
 serial: /dev/serial/by-id/XXX
 restart_method: command
 

--- a/config/cartographer.cfg
+++ b/config/cartographer.cfg
@@ -8,7 +8,8 @@ gcode:
 
 [mcu cartographer]
 is_non_critical: true
-no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+# if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+no_reconnect: true
 serial: /dev/serial/by-id/XXX
 restart_method: command
 

--- a/config/cartotouch.cfg
+++ b/config/cartotouch.cfg
@@ -6,7 +6,7 @@ gcode:
 
 [scanner]
 is_non_critical: true
-no_reconnect: true # reconnecting scanner causes klipper to crash
+no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
 serial: /dev/serial/by-id/XXX
 sensor: cartographer
 backlash_comp: 0.5

--- a/config/cartotouch.cfg
+++ b/config/cartotouch.cfg
@@ -6,7 +6,8 @@ gcode:
 
 [scanner]
 is_non_critical: true
-no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+# if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+no_reconnect: true
 serial: /dev/serial/by-id/XXX
 sensor: cartographer
 backlash_comp: 0.5

--- a/config/eddyng.cfg
+++ b/config/eddyng.cfg
@@ -1,6 +1,6 @@
 [mcu eddy]
 is_non_critical: true
-no_reconnect: true # reconnecting eddy causes klipper to crash
+no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
 serial: /dev/serial/by-id/XXX  # change this based on your device path
 restart_method: command
 

--- a/config/eddyng.cfg
+++ b/config/eddyng.cfg
@@ -1,6 +1,7 @@
 [mcu eddy]
 is_non_critical: true
-no_reconnect: true # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+# if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper
+no_reconnect: true
 serial: /dev/serial/by-id/XXX  # change this based on your device path
 restart_method: command
 


### PR DESCRIPTION
just added # if non critical mcu enabled and probe disconnects and then reconnects (physically) do not reattach to klipper upon that reconnect to avoid crashing klipper this is to clarify what no connect means hopefully improving the user experience