### PR TITLE
more comments!

### DIFF
--- a/config/cartographer.cfg
+++ b/config/cartographer.cfg
@@ -35,6 +35,7 @@ max_temp: 105
 
 [bed_mesh]
 horizontal_move_z: 3
+# anything above 200 on a K1 series printer is likely to cause stuttering
 speed: 200
 mesh_min: 999,999
 mesh_max: 999,999

--- a/config/cartographer.cfg
+++ b/config/cartographer.cfg
@@ -30,7 +30,7 @@ max_samples: 20
 sensor_type: temperature_mcu
 sensor_mcu: cartographer
 min_temp: 0
-# Cartographer V1–3 has a maximum operating temperature of 85°C, whereas the V4 is rated for operation up to 125°C. However, the integrated ADXL accelerometer remains rated for a maximum of 85°C.
+# Cartographer V3 has a maximum operating temperature of 85°C, whereas the V4 is rated for operation up to 125°C. However, the integrated ADXL accelerometer remains rated for a maximum of 85°C.
 max_temp: 105
 
 [bed_mesh]

--- a/config/cartographer.cfg
+++ b/config/cartographer.cfg
@@ -30,6 +30,7 @@ max_samples: 20
 sensor_type: temperature_mcu
 sensor_mcu: cartographer
 min_temp: 0
+# Cartographer V1–3 has a maximum operating temperature of 85°C, whereas the V4 is rated for operation up to 125°C. However, the integrated ADXL accelerometer remains rated for a maximum of 85°C.
 max_temp: 105
 
 [bed_mesh]

--- a/config/cartotouch.cfg
+++ b/config/cartotouch.cfg
@@ -25,7 +25,7 @@ scanner_touch_retract_speed: 10
 sensor_type: temperature_mcu
 sensor_mcu: scanner
 min_temp: 0
-# Cartographer V1–3 has a maximum operating temperature of 85°C, whereas the V4 is rated for operation up to 125°C. However, the integrated ADXL accelerometer remains rated for a maximum of 85°C.
+# Cartographer V3 has a maximum operating temperature of 85°C, whereas the V4 is rated for operation up to 125°C. However, the integrated ADXL accelerometer remains rated for a maximum of 85°C.
 max_temp: 105
 
 [bed_mesh]

--- a/config/cartotouch.cfg
+++ b/config/cartotouch.cfg
@@ -30,6 +30,7 @@ max_temp: 105
 
 [bed_mesh]
 horizontal_move_z: 5
+# anything above 200 on a K1 series printer is likely to cause stuttering
 speed: 200
 mesh_min: 999,999
 mesh_max: 999,999

--- a/config/cartotouch.cfg
+++ b/config/cartotouch.cfg
@@ -25,6 +25,7 @@ scanner_touch_retract_speed: 10
 sensor_type: temperature_mcu
 sensor_mcu: scanner
 min_temp: 0
+# Cartographer V1–3 has a maximum operating temperature of 85°C, whereas the V4 is rated for operation up to 125°C. However, the integrated ADXL accelerometer remains rated for a maximum of 85°C.
 max_temp: 105
 
 [bed_mesh]


### PR DESCRIPTION
adds a comment for cartographer and carto to add temp ratings for cartographer and to add the beacon warning for stuttering over 200mm/s bed mesh speed as the cartographer lite mcu is more limited then full and will cause issues