### PR TITLE
Read belt calibration data from new location.

### DIFF
--- a/k1/belts_calibration.cfg
+++ b/k1/belts_calibration.cfg
@@ -25,7 +25,7 @@ gcode:
 
       RESPOND MSG="Belts comparative frequency profile generation..."
       RESPOND MSG="This may take some time (3-5min)"
-      RUN_SHELL_COMMAND CMD=graph_belts PARAMS="-w {png_width} -l {png_height} -n -o {png_out_path} -k /usr/data/klipper /usr/data/tmp/raw_data_axis=1.000,-1.000_A.csv /usr/data/tmp/raw_data_axis=1.000,1.000_B.csv"
+      RUN_SHELL_COMMAND CMD=graph_belts PARAMS="-w {png_width} -l {png_height} -n -o {png_out_path} -k /usr/data/klipper /usr/data/tmp/raw_data_axis=1.000,-1.000,0.000_A.csv /usr/data/tmp/raw_data_axis=1.000,1.000,0.000_B.csv"
     {% else %}
       RESPOND TYPE=error MSG='Resonance tester configuration missing!'
     {% endif %}


### PR DESCRIPTION
After rebasing onto Klipper, belt calibration data has the z axis included in its file name.

This shouldn't get merged until the Klipper rebase work gets merged.