### PR TITLE
force update to grumpyscreen with wifi connection fixes and a fix for…

### DIFF
--- a/k1/installer.sh
+++ b/k1/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # this allows us to make changes to Simple AF and grumpyscreen in parallel
-GRUMPYSCREEN_TIMESTAMP=1783567800
+GRUMPYSCREEN_TIMESTAMP=1783651600
 
 if [ -f /usr/bin/get_sn_mac.sh ]; then
   MODEL=$(/usr/bin/get_sn_mac.sh model)

--- a/k1/services/S99grumpyscreen
+++ b/k1/services/S99grumpyscreen
@@ -21,6 +21,9 @@ start_server() {
 
 stop_server() {
     RC_SVCNAME=guppyscreen $SUPERVISE_DAEMON guppyscreen --stop --pidfile $PID_FILE > /dev/null 2>&1
+
+    # after stopping grumpyscreen, clear the screen with this afterwards to avoid showing a corrupted image
+    cmd_jpeg_display /usr/data/pellcorp/k1/black.jpg &
 }
 
 case "$1" in

--- a/rpi/install-grumpyscreen.sh
+++ b/rpi/install-grumpyscreen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # this allows us to make changes to Simple AF and grumpyscreen in parallel
-GRUMPYSCREEN_TIMESTAMP=1783567800
+GRUMPYSCREEN_TIMESTAMP=1783651600
 
 BASEDIR=$HOME
 source $BASEDIR/pellcorp/rpi/functions.sh


### PR DESCRIPTION
… premature sleep on first startup, due to relying on wall clock