### PR TITLE
change the wait while pre-heating bed to 50mm by default to reduce an…

### DIFF
--- a/config/start_end.cfg
+++ b/config/start_end.cfg
@@ -22,7 +22,7 @@ variable_end_print_cool_down_max_bed_temp: 70.0
 variable_end_print_keep_bed_heated: True
 # position to move the nozzle to while heating the bed (including heak soaking)
 # set this to 0 to disable this behaviour
-variable_start_print_bed_heating_move_bed_distance: 20.0
+variable_start_print_bed_heating_move_bed_distance: 50.0
 # turn off heaters before tap (eddy-ng) / touch (cartographer) / contact (beacon)
 variable_stop_heaters_for_touch: True
 # when starting heaters back up after touch, wait for bed first (cartographer only)


### PR DESCRIPTION
…y chance of unecessary heat up of the carto, beacon or eddy while waiting for the bed to preheat